### PR TITLE
feat: double quotes for strings in yaml

### DIFF
--- a/src/cobra/io/dict.py
+++ b/src/cobra/io/dict.py
@@ -91,8 +91,8 @@ def _fix_type(
         return float(value)
     if isinstance(value, np.bool):
         return bool(value)
-    if isinstance(value, set):
-        return list(value)
+    if isinstance(value, list):
+        return list(map(lambda x: _fix_type(x), value))
     if isinstance(value, dict):
         return OrderedDict((key, _fix_type(value[key])) for key in sorted(value))
     # handle legacy Formula type

--- a/src/cobra/io/dict.py
+++ b/src/cobra/io/dict.py
@@ -85,7 +85,7 @@ def _fix_type(
     """
     # Because numpy floats can not be pickled to json
     if isinstance(value, str):
-        return str(value)
+        return f'"{value}"'
     if isinstance(value, np.float):
         return float(value)
     if isinstance(value, np.bool):

--- a/src/cobra/io/dict.py
+++ b/src/cobra/io/dict.py
@@ -94,7 +94,7 @@ def _fix_type(
     if isinstance(value, set):
         return list(value)
     if isinstance(value, dict):
-        return OrderedDict((key, value[key]) for key in sorted(value))
+        return OrderedDict((key, _fix_type(value[key])) for key in sorted(value))
     # handle legacy Formula type
     if value.__class__.__name__ == "Formula":
         return str(value)

--- a/src/cobra/io/dict.py
+++ b/src/cobra/io/dict.py
@@ -9,6 +9,7 @@ import numpy as np
 from ..core import Gene, Metabolite, Model, Reaction
 from ..util.solver import set_objective
 
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 if TYPE_CHECKING:
     from cobra import Object
@@ -85,7 +86,7 @@ def _fix_type(
     """
     # Because numpy floats can not be pickled to json
     if isinstance(value, str):
-        return f'"{value}"'
+        return DoubleQuotedScalarString(value)
     if isinstance(value, np.float):
         return float(value)
     if isinstance(value, np.bool):

--- a/src/cobra/io/yaml.py
+++ b/src/cobra/io/yaml.py
@@ -55,7 +55,6 @@ class CobraYAML(YAML):
 
 yaml = CobraYAML(typ="rt")
 
-
 def to_yaml(model: "Model", sort: bool = False, **kwargs: Any) -> str:
     """Return the model as a YAML string.
 
@@ -133,6 +132,7 @@ def save_yaml_model(
     """
     obj = model_to_dict(model, sort=sort)
     obj["version"] = YAML_SPEC
+    yaml.preserve_quotes = True
     if isinstance(filename, str):
         with io.open(filename, "w") as file_handle:
             yaml.dump(obj, file_handle, **kwargs)


### PR DESCRIPTION
<!--
* [ ] fix #(issue number)
* [ ] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../release-notes/next-release.md)
-->

This PR aims to modify the output of models in YAML by changing the type of the string in the output dict. ⚠️ This might have consequences in outputting in other file formats - this should be further looked into.

#### How to test
```
gh repo clone haowang-bioinfo/cobrapy
python3 -m venv my-env
source my-env/bin/activate
cd cobrapy
git checkout feat/output-quotes
pip install -e ".[development]"
cd src/
python3
>>> import cobra
>>> from cobra.io import load_yaml_model, save_yaml_model
>>> model = load_yaml_model("../../Human-GEM/model/Human-GEM.yml")
>>> save_yaml_model(model, "test.yml")
>>> exit()
deactivate
diff ../../Human-GEM/model/Human-GEM.yml test.yml
```

The `diff` will show the imported and exported yml files are identical with regards to quote styles. There are several yaml fields specific to `Human-GEM` that are not covered by `cobrapy`, such as: `metFrom`, `rxnNotes`, `rxnFrom`, so they will be picked up by the diff. Moreover, it seems `cobrapy` splits long strings on multiple lines, e.g., in the case of long GPR rules. Lastly, the are a few minor differences in the spacing for the `genes` section and maybe a couple of missing `    - !!omap`s.


